### PR TITLE
deps: replace derivative with educe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,17 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,10 +224,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
 
 [[package]]
 name = "errno"
@@ -782,7 +803,7 @@ name = "ratatui-explorer"
 version = "0.1.3"
 dependencies = [
  "crossterm",
- "derivative",
+ "educe",
  "ratatui",
  "termion",
  "termwiz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ termion = { version = "4.0.2", optional = true }
 termwiz = { version = "0.22", optional = true }
 
 ratatui = { version = "0.29", features = ["unstable-widget-ref"] }
-derivative = "2.2"
+educe = { version = "0.6.0", features = ["Debug", "PartialEq", "Eq", "Hash"] }
 
 [features]
 default = ["crossterm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ termion = { version = "4.0.2", optional = true }
 termwiz = { version = "0.22", optional = true }
 
 ratatui = { version = "0.29", features = ["unstable-widget-ref"] }
-educe = { version = "0.6.0", features = ["Debug", "PartialEq", "Eq", "Hash"] }
+educe = { version = "0.6.0", features = ["Debug", "PartialEq", "Eq", "Hash"], default-features = false }
 
 [features]
 default = ["crossterm"]

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -72,13 +72,13 @@ impl File {
 /// You can also wrap the widget in a block with the [Theme::with_block](#method.block)
 /// method and add customizable titles to it with [Theme::with_title_top](#method.title_top)
 /// and [Theme::with_title_bottom](#method.title_bottom).
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, educe::Educe)]
+#[educe(Debug, PartialEq, Eq, Hash)]
 pub struct Theme {
     block: Option<Block<'static>>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore", Hash = "ignore")]
+    #[educe(Debug(ignore), PartialEq(ignore), Hash(ignore))]
     title_top: Vec<LineFactory>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore", Hash = "ignore")]
+    #[educe(Debug(ignore), PartialEq(ignore), Hash(ignore))]
     title_bottom: Vec<LineFactory>,
     style: Style,
     item_style: Style,


### PR DESCRIPTION
I picked `educe` because its API looked be the closest to `derivative`.

Fixes #5 
