### PR TITLE
Fix documentation tests on windows machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then inside your `main.rs` file:
 ```rust no_run
 use std::io::{self, stdout};
 
+use ratatui::crossterm;
 use crossterm::{
     event::{read, Event, KeyCode},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},

--- a/src/file_explorer.rs
+++ b/src/file_explorer.rs
@@ -781,8 +781,6 @@ impl File {
     /// ```
     /// You can know if the selected file is a directory like this:
     /// ```no_run
-    /// use std::os::unix::fs::FileTypeExt;
-    ///
     /// use ratatui_explorer::FileExplorer;
     ///
     /// let file_explorer = FileExplorer::new().unwrap();
@@ -790,14 +788,12 @@ impl File {
     /// /* user select `password.png` */
     ///
     /// let file = file_explorer.current();
-    /// assert_eq!(file.file_type().unwrap().is_file(), true);
-    /// assert_eq!(file.file_type().unwrap().is_socket(), false);
+    /// assert_eq!(file.file_type().unwrap().is_dir(), false);
     ///
     /// /* user select `Documents` */
     ///
     /// let file = file_explorer.current();
-    /// assert_eq!(file.file_type().unwrap().is_file(), false);
-    /// assert_eq!(file.file_type().unwrap().is_socket(), false);
+    /// assert_eq!(file.file_type().unwrap().is_dir(), true);
     /// ```
     #[inline]
     #[must_use]


### PR DESCRIPTION
When trying to fix another issues on my windows machine, I wasn't able to get a passing `cargo test` run after doing a fresh clone. The offending tests seemed to both be documentation tests, which I have tried to fix in a way I hope is helpful.

---

**[file_explorer.rs doc tests passing on windows](https://github.com/tatounee/ratatui-explorer/commit/0325d99015d66b5b245d88fc5f0c8edb0ef505a5)**

Cleaning up failures when running `cargo test` on a fresh clone on
a Windows machine.

The previous doc tests for the `file_type` function used the unix
FileTypeExt to demonstrate testing to see if a file is a directory.
Which fails on windows. The tests were marked as `no_run`, but this
only prevents the doc test from running - `cargo test` will still try to
build the code.

Modified the documentation to use `FileType::is_dir`, which has been
stable since 2015 via Rust 1.1
[link](https://doc.rust-lang.org/std/fs/struct.FileType.html#method.is_dir).

Alternative implementations:
* use `ignore` instead of `no_run` which will actually cause doc test to
  fully ignore the sample code
* document something else a user could do with the file type

---

**[doc tests from README.md in lib.rs passing](https://github.com/tatounee/ratatui-explorer/commit/4a00b7513d52a8e506829cdf90c5c106327470f1)**

Cleaning up failures when running `cargo test` on a fresh clone.

The sample code in `README.md` is pulled in as rust documentation
through an `include_str!` macro, but caused a doc test failure when
trying to access modules in the `crossterm` crate.

Similar to the code in `examples/`, modified the sample code in
`README.md` to access crossterm functionality through
`ratatui::crossterm` rather than directly through the `crossterm` crate.