### PR TITLE
Quiet warnings from a new Rust 1.89 lint (mismatched lifetimes)

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -445,7 +445,7 @@ impl Theme {
     /// Returns the generated top titles of the theme.
     #[inline]
     #[must_use]
-    pub fn title_top(&self, file_explorer: &FileExplorer) -> Vec<Line> {
+    pub fn title_top(&self, file_explorer: &FileExplorer) -> Vec<Line<'_>> {
         self.title_top
             .iter()
             .map(|title_top| title_top(file_explorer))
@@ -455,7 +455,7 @@ impl Theme {
     /// Returns the generated bottom titles of the theme.
     #[inline]
     #[must_use]
-    pub fn title_bottom(&self, file_explorer: &FileExplorer) -> Vec<Line> {
+    pub fn title_bottom(&self, file_explorer: &FileExplorer) -> Vec<Line<'_>> {
         self.title_bottom
             .iter()
             .map(|title_bottom| title_bottom(file_explorer))


### PR DESCRIPTION
While trying to fix another issue, this new warning popped up for me. I hope this fix might be helpful.

---

Fix the warning generated by the new "Mismatched lifetimes syntax" lint added in
[Rust 1.89.0](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint).