### PR TITLE
set_cwd does not change display dir on failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -787,12 +793,40 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -829,6 +863,16 @@ version = "0.2.1"
 dependencies = [
  "educe",
  "ratatui",
+ "tempdir",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -885,6 +929,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustix"
@@ -1055,6 +1108,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,8 @@ crossterm = ["ratatui/crossterm"]
 termion = ["ratatui/termion"]
 termwiz = ["ratatui/termwiz"]
 
+[dev-dependencies]
+tempdir = "0.3.7"
+
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/src/file_explorer.rs
+++ b/src/file_explorer.rs
@@ -1,4 +1,4 @@
-use std::{fs::FileType, io::Result, path::PathBuf};
+use std::{fs::FileType, io::Result, path::Path, path::PathBuf};
 
 use ratatui::widgets::WidgetRef;
 
@@ -85,16 +85,14 @@ impl FileExplorer {
     /// ```
     pub fn new() -> Result<FileExplorer> {
         let cwd = std::env::current_dir()?;
-
-        let mut file_explorer = Self {
+        let files = Self::get_files(&cwd, false)?;
+        let file_explorer = Self {
             cwd,
-            files: vec![],
+            files,
             show_hidden: false,
             selected: 0,
             theme: Theme::default(),
         };
-
-        file_explorer.get_and_set_files()?;
 
         Ok(file_explorer)
     }
@@ -232,16 +230,14 @@ impl FileExplorer {
                 let parent = self.cwd.parent();
 
                 if let Some(parent) = parent {
-                    self.cwd = parent.to_path_buf();
-                    self.get_and_set_files()?;
-                    self.selected = 0;
+                    let path = parent.to_path_buf();
+                    self.set_cwd(path)?;
                 }
             }
             Input::Right => {
                 if self.files[self.selected].path.is_dir() {
-                    self.cwd = self.files.swap_remove(self.selected).path;
-                    self.get_and_set_files()?;
-                    self.selected = 0;
+                    let path = self.files.swap_remove(self.selected).path;
+                    self.set_cwd(path)?;
                 }
             }
             Input::ToggleShowHidden => self.set_show_hidden(!self.show_hidden)?,
@@ -269,8 +265,9 @@ impl FileExplorer {
     /// ```
     #[inline]
     pub fn set_cwd<P: Into<PathBuf>>(&mut self, cwd: P) -> Result<()> {
-        self.cwd = cwd.into();
-        self.get_and_set_files()?;
+        let cwd = cwd.into();
+        self.files = Self::get_files(&cwd, self.show_hidden)?;
+        self.cwd = cwd;
         self.selected = 0;
 
         Ok(())
@@ -295,7 +292,7 @@ impl FileExplorer {
     #[inline]
     pub fn set_show_hidden(&mut self, show_hidden: bool) -> Result<()> {
         self.show_hidden = show_hidden;
-        self.get_and_set_files()?;
+        self.files = Self::get_files(&self.cwd, show_hidden)?;
         self.selected = 0;
 
         Ok(())
@@ -530,8 +527,8 @@ impl FileExplorer {
 
     /// Get the files and directories in the current working directory and set them in the file explorer.
     /// It add the parent directory at the beginning of the [`Vec`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html) of files if it exist.
-    fn get_and_set_files(&mut self) -> Result<()> {
-        let (mut dirs, mut none_dirs): (Vec<_>, Vec<_>) = std::fs::read_dir(&self.cwd)?
+    fn get_files(working_dir: &Path, show_hidden: bool) -> Result<Vec<File>> {
+        let (mut dirs, mut none_dirs): (Vec<_>, Vec<_>) = std::fs::read_dir(working_dir)?
             .filter_map(|entry| {
                 let entry = entry.ok()?;
                 let path = entry.path();
@@ -563,7 +560,7 @@ impl FileExplorer {
                     is_hidden,
                     file_type,
                 };
-                if !self.show_hidden && file.is_hidden() {
+                if !show_hidden && file.is_hidden() {
                     None
                 } else {
                     Some(file)
@@ -574,7 +571,7 @@ impl FileExplorer {
         dirs.sort_unstable_by(|f1, f2| f1.name.cmp(&f2.name));
         none_dirs.sort_unstable_by(|f1, f2| f1.name.cmp(&f2.name));
 
-        if let Some(parent) = self.cwd.parent() {
+        let files = if let Some(parent) = working_dir.parent() {
             let mut files = Vec::with_capacity(1 + dirs.len() + none_dirs.len());
 
             files.push(File {
@@ -588,17 +585,17 @@ impl FileExplorer {
             files.extend(dirs);
             files.extend(none_dirs);
 
-            self.files = files;
+            files
         } else {
             let mut files = Vec::with_capacity(dirs.len() + none_dirs.len());
 
             files.extend(dirs);
             files.extend(none_dirs);
 
-            self.files = files;
+            files
         };
 
-        Ok(())
+        Ok(files)
     }
 }
 
@@ -803,5 +800,28 @@ impl File {
     #[must_use]
     pub const fn file_type(&self) -> Option<FileType> {
         self.file_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_set_cwd_does_not_change_displayed_path_on_failure() -> Result<()> {
+        let tmp_dir = TempDir::new("cwd_does_not_change_on_failure")?;
+        let does_not_exist_path = tmp_dir.path().join("does_not_exist");
+        assert!(!does_not_exist_path.exists());
+
+        let mut explorer = FileExplorer::new()?;
+        let previous_cwd = explorer.cwd().clone();
+
+        let result = explorer.set_cwd(does_not_exist_path);
+        assert!(result.is_err());
+        assert_eq!(&previous_cwd, explorer.cwd());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
I ran into an issue using this crate, when trying to do something like this:

```rust
let file_explorer = FileExplorer::new();
let default_path = some_preferred_path();
// try to set, but I'm not worried if it fails
let _ = file_explorer.set_cwd(default_path);
```

When `set_cwd` fails because the path does not exist, this results in the non-existent path being displayed, but the displayed files are unchanged (belonging to whatever the cwd was previously).

My intention was to try to set the path to some preferred default, but not to panic if this fails. I am able to get around this by checking to see if the path exists before calling `set_cwd`, but in any case, it seems wrong to put the `FileExplorer` in an inconsistent state.

I'm sharing this PR with how I've fixed this locally. Of course, the maintaner(s) should feel free to use / tweak / reject this as they see fit.

---

Previously, calling `FileExplorer::set_cwd` on a path that does not exist (or fails the inner `get_and_set_files` call for any other reason) would result in the FileExplorer claiming to be set in the erroneous directory, while still listing the contents of whatever directory it was previously set up from.

This can happen if a user manually handles the result (without `unwrap`-ing or panicking, etc.), but continues to use the `FileExplorer`.